### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # react-tabs-handler
-Presentation-less component to build robust tabs
+Presentation-less component to build robust tabs.
 
 ## The why
-The component take inspiration from [downshift](downshift) (an awesome [Kent C. Dodds](kent)'s component for dropdown / select / combobox, etc.) and try to accomplish the same thing for the tabs problem presented in the ["Compound Components"](compound-components-talk) talk from [Ryan Florence](ryan), using the "getter props" pattern instead.
+This component takes inspiration from [downshift](downshift) (an awesome component from [Kent C. Dodds](kent) for dropdown / select / combobox, etc.) and tries to apply the same solution to the tabs problem presented in the ["Compound Components"](compound-components-talk) talk from [Ryan Florence](ryan) by using the "getter props" pattern instead.
 
-Even if the frontend developer experience is evolved during the last years, is still difficult to find a good component flexible still robust enough.
+Even if the frontend development experience has evolved positively in the last years, it's still hard to find a good component that does the job, it's flexible yet it's robust enough for production use. The aim of this project is to fill this gap.
 
 ## Installation
 The component has not been released, yet.


### PR DESCRIPTION
I've done some correction on the README.md and on some of the wording. I still feel the "The why" paragraph can be simplified by removing parenthesis which break the flow, such as `(an awesome component from [Kent C. Dodds](kent) for dropdown / select / combobox, etc.)`, maybe moving them to some other "inspiration" paragraph or something like that.